### PR TITLE
5968 Update Service Metadata

### DIFF
--- a/mainServiceController/src/main/java/org/venice/piazza/servicecontroller/Application.java
+++ b/mainServiceController/src/main/java/org/venice/piazza/servicecontroller/Application.java
@@ -14,6 +14,7 @@
  * limitations under the License.
  *******************************************************************************/
 package org.venice.piazza.servicecontroller;
+
 import java.util.Arrays;
 
 import org.springframework.boot.SpringApplication;
@@ -22,11 +23,14 @@ import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.context.web.SpringBootServletInitializer;
 import org.springframework.context.ApplicationContext;
-
+import org.springframework.context.annotation.Bean;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
+
 /**
- * Main class for the pz-servicecontroller.  Launches the application
+ * Main class for the pz-servicecontroller. Launches the application
+ * 
  * @author mlynum
  * @since 1.0
  */
@@ -37,48 +41,48 @@ import org.springframework.scheduling.annotation.EnableAsync;
 @EnableMongoRepositories("org.venice.piazza.serviceregistry.data.mongodb.repository")
 /* Enable Boot application and MongoRepositories */
 public class Application extends SpringBootServletInitializer {
-	
-    
+
 	@Override
 	protected SpringApplicationBuilder configure(SpringApplicationBuilder builder) {
-		
+
 		return builder.sources(Application.class);
 	}
 
 	public static void main(String[] args) {
-		
 
 		ApplicationContext ctx = SpringApplication.run(Application.class, args);
-		
-		
+
 		// now check to see if the first parameter is true, if so then test the health of the
 		// Spring environment
 		if (args.length == 1) {
-            // Get the value of the first argument
+			// Get the value of the first argument
 			// If it is true then do a health check and print it out
 			Boolean inspectBool = Boolean.valueOf(args[0]);
 			if (inspectBool.booleanValue() == true) {
 				inspectSprintEnv(ctx);
 			}
-		}               
-		
+		}
+
 	}
-	
+
 	/**
 	 * Determines if the appropriate bean definitions are available
 	 */
 	public static void inspectSprintEnv(ApplicationContext ctx) {
-		
+
 		System.out.println("Spring Boot Beans");
 		System.out.println("-----------------");
 
-        String[] beanNames = ctx.getBeanDefinitionNames();
-        Arrays.sort(beanNames);
-        for (String beanName : beanNames) {
-            System.out.println(beanName);
-        }
-		
+		String[] beanNames = ctx.getBeanDefinitionNames();
+		Arrays.sort(beanNames);
+		for (String beanName : beanNames) {
+			System.out.println(beanName);
+		}
+
+	}
+
+	@Bean
+	public LocalValidatorFactoryBean getLocalValidatorFactoryBean() {
+		return new LocalValidatorFactoryBean();
 	}
 }
-
-

--- a/mainServiceController/src/main/java/org/venice/piazza/servicecontroller/controller/ServiceController.java
+++ b/mainServiceController/src/main/java/org/venice/piazza/servicecontroller/controller/ServiceController.java
@@ -249,7 +249,7 @@ public class ServiceController {
 			
 			// Ensure the Service is still valid, with the new merged changes
 			Errors errors = new BeanPropertyBindingResult(existingService, existingService.getClass().getName());
-			validator.validate(existingService, errors, Service.class);
+			validator.validate(existingService, errors);
 			if ((errors != null) && (errors.hasErrors())) {
 				// Build up the list of Errors
 				StringBuilder builder = new StringBuilder();

--- a/mainServiceController/src/main/java/org/venice/piazza/servicecontroller/controller/ServiceController.java
+++ b/mainServiceController/src/main/java/org/venice/piazza/servicecontroller/controller/ServiceController.java
@@ -20,12 +20,15 @@ import java.util.Map;
 
 import javax.servlet.http.HttpServletResponse;
 
-
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BeanPropertyBindingResult;
+import org.springframework.validation.Errors;
+import org.springframework.validation.ObjectError;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -48,14 +51,13 @@ import model.data.DataType;
 import model.job.type.RegisterServiceJob;
 import model.request.PiazzaJobRequest;
 import model.response.ErrorResponse;
-import model.response.SuccessResponse;
 import model.response.PiazzaResponse;
-import model.response.ServiceResponse;
 import model.response.ServiceIdResponse;
+import model.response.ServiceResponse;
+import model.response.SuccessResponse;
 import model.service.SearchCriteria;
 import model.service.metadata.ExecuteServiceData;
 import model.service.metadata.Service;
-
 import util.PiazzaLogger;
 
 /**
@@ -69,7 +71,9 @@ import util.PiazzaLogger;
 @RestController
 @RequestMapping({ "/servicecontroller", "" })
 public class ServiceController {
-
+	@Autowired
+	private LocalValidatorFactoryBean validator;
+	
 	@Autowired
 	private DeleteServiceHandler dlHandler;
 
@@ -226,34 +230,46 @@ public class ServiceController {
 	 * @return Null if the service has been updated, or an appropriate error if
 	 *         there is one.
 	 */
-	
 	@RequestMapping(value = "/service/{serviceId}", method = RequestMethod.PUT, produces = MediaType.APPLICATION_JSON_VALUE)
 	public ResponseEntity<PiazzaResponse> updateServiceMetadata(@PathVariable(value = "serviceId") String serviceId, @RequestBody Service serviceData) {
 		try {
-			if ((serviceId != null) && (!serviceId.isEmpty())) {
-				logger.log(String.format("Updating Service with ID %s", serviceId), PiazzaLogger.INFO);
-	
-				/* // Check if Service exists
-				try {
-					Service sMetadata = accessor.getServiceById(serviceId);
-
-				} catch(ResourceAccessException rae) {
-					return new ResponseEntity<PiazzaResponse>(new ErrorResponse(String.format("Service not found: %s", serviceId), "Service Controller"), HttpStatus.NOT_FOUND);
-				} */
-				serviceData.setServiceId(serviceId);
-				String result = usHandler.handle(serviceData);
-				if (result.length() > 0) {
-					return new ResponseEntity<PiazzaResponse>(new SuccessResponse("Service was updated successfully.", "ServiceController"), HttpStatus.OK);
-				} else {
-					return new ResponseEntity<PiazzaResponse>(new ErrorResponse("The update for serviceId " + serviceId + " did not happen successfully", "ServiceController"), HttpStatus.INTERNAL_SERVER_ERROR);
-				}
-
-
-			} else {
-			 	return new ResponseEntity<PiazzaResponse>(new ErrorResponse("The serviceId was not specified", "Service Controller"), HttpStatus.BAD_REQUEST);
-
+			// Ensure valid input
+			if ((serviceId == null) || (serviceId.isEmpty())) {
+				return new ResponseEntity<PiazzaResponse>(new ErrorResponse("The serviceId was not specified", "Service Controller"), HttpStatus.BAD_REQUEST);
 			}
+			
+			// Get the existing service.
+			Service existingService = accessor.getServiceById(serviceId);
+			
+			// Log
+			logger.log(String.format("Updating Service with ID %s", serviceId), PiazzaLogger.INFO);
+			
+			// Merge the new defined properties into the existing service
+			existingService.merge(serviceData, false);
+			
+			// Ensure the Service is still valid, with the new merged changes
+			Errors errors = new BeanPropertyBindingResult(existingService, existingService.getClass().getName());
+			validator.validate(existingService, errors, Service.class);
+			if ((errors != null) && (errors.hasErrors())) {
+				// Build up the list of Errors
+				StringBuilder builder = new StringBuilder();
+				for (ObjectError error : errors.getAllErrors()) {
+					builder.append(error.getDefaultMessage() + ".");
+				}
+				throw new Exception(String.format("Error validating updated Service Metadata. Validation Errors: %s", builder.toString()));
+			}
+
+			// Update Existing Service in mongo
+			existingService.setServiceId(serviceId);
+			String result = usHandler.handle(existingService);
+			if (result.length() > 0) {
+				return new ResponseEntity<PiazzaResponse>(new SuccessResponse("Service was updated successfully.", "ServiceController"), HttpStatus.OK);
+			} else {
+				return new ResponseEntity<PiazzaResponse>(new ErrorResponse("The update for serviceId " + serviceId + " did not happen successfully", "ServiceController"), HttpStatus.INTERNAL_SERVER_ERROR);
+			}
+
 		} catch (Exception exception) {
+			exception.printStackTrace();
 			String error = String.format("Error Updating service %s: %s", serviceId, exception.getMessage());
 			logger.log(error, PiazzaLogger.ERROR);
 			return new ResponseEntity<PiazzaResponse>(new ErrorResponse(error, "ServiceController"), HttpStatus.INTERNAL_SERVER_ERROR);

--- a/mainServiceController/src/test/java/org/venice/piazza/servicecontroller/ServiceControllerTest.java
+++ b/mainServiceController/src/test/java/org/venice/piazza/servicecontroller/ServiceControllerTest.java
@@ -19,7 +19,9 @@ import static org.hamcrest.CoreMatchers.instanceOf;
  * Class of unit tests to test the deletion of services
  * @author mlynum
  */
-import static org.junit.Assert.*;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -32,11 +34,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
-
 import org.mongojack.JacksonDBCollection;
 import org.powermock.modules.junit4.PowerMockRunner;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 import org.springframework.web.client.ResourceAccessException;
 import org.venice.piazza.servicecontroller.controller.ServiceController;
 import org.venice.piazza.servicecontroller.data.mongodb.accessors.MongoAccessor;
@@ -61,9 +63,9 @@ import model.request.PiazzaJobRequest;
 import model.response.ErrorResponse;
 import model.response.Pagination;
 import model.response.PiazzaResponse;
+import model.response.ServiceIdResponse;
 import model.response.ServiceListResponse;
 import model.response.ServiceResponse;
-import model.response.ServiceIdResponse;
 import model.response.SuccessResponse;
 import model.service.SearchCriteria;
 import model.service.metadata.ExecuteServiceData;
@@ -109,6 +111,9 @@ public class ServiceControllerTest {
 	
 	@Mock 
 	private PiazzaLogger loggerMock;
+	
+	@Mock
+	private LocalValidatorFactoryBean validator;
 	
 	@InjectMocks
 	private org.mongojack.DBCursor<Service> dbCursorMock;
@@ -310,11 +315,12 @@ public class ServiceControllerTest {
 	}
 
 	@Test
-	public void testUpdateServiceMetadata() {
+	public void testUpdateServiceMetadata() throws Exception{
 
 		String testServiceId = "9a6baae2-bd74-4c4b-9a65-c45e8cd9060";
 		service.setServiceId(testServiceId);
 		Mockito.doReturn("Update Successful").when(usHandlerMock).handle(service);
+		Mockito.doReturn(service).when(accessorMock).getServiceById(Mockito.eq("9a6baae2-bd74-4c4b-9a65-c45e8cd9060"));
 
 		ResponseEntity<PiazzaResponse> piazzaResponse = sc.updateServiceMetadata(testServiceId, service);
 		assertThat("The update of service metadata should be successful", piazzaResponse.getBody(), instanceOf(SuccessResponse.class));
@@ -328,6 +334,7 @@ public class ServiceControllerTest {
 		String testServiceId = "9a6baae2-bd74-4c4b-9a65-c45e8cd9060";
 		service.setServiceId("123-23323bsr");
 		Mockito.doReturn("Update Successful").when(usHandlerMock).handle(service);
+		Mockito.doReturn(service).when(accessorMock).getServiceById(Mockito.eq(testServiceId));
 
 		ResponseEntity<PiazzaResponse> piazzaResponse = sc.updateServiceMetadata(testServiceId, service);
 		assertThat("The update of service metadata should be  successful", piazzaResponse.getBody(), instanceOf(SuccessResponse.class));
@@ -343,6 +350,7 @@ public class ServiceControllerTest {
 		String testServiceId = "9a6baae2-bd74-4c4b-9a65-c45e8cd9060";
 		service.setServiceId(testServiceId);
 		Mockito.doReturn("").when(usHandlerMock).handle(service);
+		Mockito.doReturn(service).when(accessorMock).getServiceById(Mockito.eq(testServiceId));
 
 		ResponseEntity<PiazzaResponse> piazzaResponse = sc.updateServiceMetadata(testServiceId, service);
 		assertThat("The update of service metadata should be unsuccessful", piazzaResponse.getBody(), instanceOf(ErrorResponse.class));
@@ -357,6 +365,7 @@ public class ServiceControllerTest {
 		String testServiceId = "9a6baae2-bd74-4c4b-9a65-c45e8cd9060";
 		service.setServiceId(testServiceId);
 		Mockito.doThrow(new MongoException("There was an error")).when(usHandlerMock).handle(service);
+		Mockito.doReturn(service).when(accessorMock).getServiceById(Mockito.eq(testServiceId));
 
 		ResponseEntity<PiazzaResponse> piazzaResponse = sc.updateServiceMetadata(testServiceId, service);
 		assertThat("The update of service metadata should be unsuccessful", piazzaResponse.getBody(), instanceOf(ErrorResponse.class));


### PR DESCRIPTION
Updating services now only updates non-null values as specified in the Service. Validation is performed *after* merging the new Service properties, so that users don't have to specify old data - only the data they want to change. 